### PR TITLE
Added TREE_TYPE in BTree abstract class

### DIFF
--- a/BSTrees/src/main/kotlin/BTree.kt
+++ b/BSTrees/src/main/kotlin/BTree.kt
@@ -1,7 +1,9 @@
-abstract class BTree<K : Comparable<K>, V, NODE_TYPE : Node<K, V, NODE_TYPE>>(private var root: NODE_TYPE) {
+abstract class BTree<K : Comparable<K>, V, NODE_TYPE : Node<K, V, NODE_TYPE>, TREE_TYPE : BTree<K, V, NODE_TYPE, TREE_TYPE>>(
+    private var root: NODE_TYPE
+) {
 
-    private var leftBTree: BTree<K, V, NODE_TYPE>? = null
-    private var rightBTree: BTree<K, V, NODE_TYPE>? = null
+    private var leftBTree: TREE_TYPE? = null
+    private var rightBTree: TREE_TYPE? = null
 
     fun getRoot() = this.root
 
@@ -11,13 +13,13 @@ abstract class BTree<K : Comparable<K>, V, NODE_TYPE : Node<K, V, NODE_TYPE>>(pr
 
     fun getLeftTree() = this.leftBTree
 
-    fun setLeftTree(newValue: BTree<K, V, NODE_TYPE>?) {
+    fun setLeftTree(newValue: TREE_TYPE?) {
         this.leftBTree = newValue
     }
 
     fun getRightTree() = this.rightBTree
 
-    fun setRightTree(newValue: BTree<K, V, NODE_TYPE>?) {
+    fun setRightTree(newValue: TREE_TYPE?) {
         this.rightBTree = newValue
     }
 

--- a/BSTrees/src/main/kotlin/avlTree/AvlTree.kt
+++ b/BSTrees/src/main/kotlin/avlTree/AvlTree.kt
@@ -3,7 +3,7 @@ package avlTree
 import balancers.AvlBalancer
 import BTree
 
-class AvlTree<K: Comparable<K>, V>(root: AvlNode<K, V>): BTree<K, V, AvlNode<K, V>>(root){
+class AvlTree<K: Comparable<K>, V>(root: AvlNode<K, V>): BTree<K, V, AvlNode<K, V>, AvlTree<K, V>>(root){
 
     private val balancer = AvlBalancer()
 

--- a/BSTrees/src/main/kotlin/binarySearchTree/BSTree.kt
+++ b/BSTrees/src/main/kotlin/binarySearchTree/BSTree.kt
@@ -2,7 +2,7 @@ package binarySearchTree
 
 import BTree
 
-class BSTree<K: Comparable<K>, V>(root: BSNode<K, V>): BTree<K, V, BSNode<K, V>>(root) {
+class BSTree<K: Comparable<K>, V>(root: BSNode<K, V>): BTree<K, V, BSNode<K, V>, BSTree<K, V>>(root) {
 
     override fun add(node: BSNode<K, V>) {
         TODO("Not yet implemented")

--- a/BSTrees/src/main/kotlin/redBlackTree/RBTree.kt
+++ b/BSTrees/src/main/kotlin/redBlackTree/RBTree.kt
@@ -3,7 +3,7 @@ package redBlackTree
 import BTree
 import balancers.RBBalancer
 
-class RBTree<K: Comparable<K>, V>(root: RBNode<K, V>): BTree<K, V, RBNode<K, V>>(root) {
+class RBTree<K: Comparable<K>, V>(root: RBNode<K, V>): BTree<K, V, RBNode<K, V>, RBTree<K, V>>(root) {
 
     private val balancer = RBBalancer()
 


### PR DESCRIPTION
## Description

Added TREE_TYPE in BTree abstract class.
<img width="352" alt="image" src="https://user-images.githubusercontent.com/73890886/227812240-b9b07a57-1de9-457e-8deb-1e1d1ac38d61.png">

Now leftBTree and rightBTree have their own tree type




## Self-check list

- [x] PR **title** and **description** are clear and intelligible.
- [x] I've added enough **comments** to my code, particularly in hard-to-understand areas.
- [ ] The functionality I've repaired, changed or added is covered with **automated tests**.
- [x] **Manual tests** have been provided optionally.
